### PR TITLE
chore: caches circuit compilation using circuit hash

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -4,7 +4,7 @@ out = "out"
 solc = "0.8.19"
 libs = ["node_modules", "lib"]
 ffi = true
-fs_permissions = [{ access = "read-write", path = ".axiom" }]
+fs_permissions = [{ access = "read-write", path = ".axiom" }, { access = "read", path = "test/circuit/average.circuit.ts" }]
 
 [rpc_endpoints]
 sepolia = "${PROVIDER_URI_SEPOLIA}"


### PR DESCRIPTION
Attempts to implement solution for #12 

- In foundry.toml read access must be given to circuit file
- A hash is taken of the circuit file plus the mock boolean flag. If mock isn't taken into account it will fail to recompile when flag is changed
- Wanted to check for hash file existence using `vm.isFile` but this is throwing an error `[FAIL. Reason: Setup failed: Invalid data]`, I'm not sure why and perhaps I'm missing something 